### PR TITLE
[codex] Align itchat-uos README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
    
 ## 对于微信Web端无法登陆的小伙伴请注意
 
-请使用 ```pip install itchat-uos==1.5.0.dev0``` 安装后，web版本可用。
+请使用 ```pip install itchat-uos==1.5.0.dev``` 安装后，web版本可用。
 
 ## 配置信息
 


### PR DESCRIPTION
## Summary
- Align the README itchat-uos install command with requirements.txt.

## Why
README used `itchat-uos==1.5.0.dev0`, while `requirements.txt` uses `itchat-uos==1.5.0.dev`.

## Validation
- Documentation-only change.
- Confirmed pip resolves `itchat-uos==1.5.0.dev` to `1.5.0.dev0`.